### PR TITLE
Fix comment to use all_ instead of all

### DIFF
--- a/src/Styled.elm
+++ b/src/Styled.elm
@@ -3231,7 +3231,7 @@ transformStyle =
 
     transition <delay> <duration> <property> <timing-function>
 
-    transition (ms 100) (s 1) all ease
+    transition (ms 100) (s 1) all_ ease
 
 -}
 transition :


### PR DESCRIPTION
Looks like the example property in the comment is missing the underscore at the end. Adding it compiles.