### PR TITLE
Use "rgb" css property for `rgb` function

### DIFF
--- a/src/Styled.elm
+++ b/src/Styled.elm
@@ -3660,7 +3660,7 @@ hex value =
 rgb : Int -> Int -> Int -> Color {}
 rgb red green blue =
     createColor
-        ("rgba("
+        ("rgb("
             ++ (toString red)
             ++ ", "
             ++ (toString green)


### PR DESCRIPTION
Looks like an additional "a" managed to sneak in at the end of the "rgb" property.