### PR TITLE
Fix transition time and delay in comment

### DIFF
--- a/src/Styled.elm
+++ b/src/Styled.elm
@@ -3230,7 +3230,7 @@ transformStyle =
 
 {-| Defines the transition between two states of an element. [`transition`](https://developer.mozilla.org/en-US/docs/Web/CSS/transition)
 
-    transition <delay> <duration> <property> <timing-function>
+    transition <duration> <delay> <property> <timing-function>
 
     transition (ms 100) (s 1) all_ ease
 


### PR DESCRIPTION
Hi,
The time and delay seem to be mixed up.
Calling this `transition (ms 0) (ms 1000) all_ linear` in elm produces this CSS: `transition: all 0ms linear 1000ms;`, while it should be `transition: all 1000ms linear 0ms;` according to this: https://developer.mozilla.org/en-US/docs/Web/CSS/transition. The line we're after is this one: `/* property name | duration | timing function | delay */`
This commit simply changes the order in the comment to get the expected result.